### PR TITLE
[feat]: Spring Batch를 사용하여 발전소 위치 csv파일을 db에 저장

### DIFF
--- a/eco-location-back/build.gradle
+++ b/eco-location-back/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 }
 
 tasks.named('test') {

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/EcoLocationBackApplication.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/EcoLocationBackApplication.java
@@ -1,9 +1,11 @@
 package kr.ac.kumoh.webkit.ecolocationback;
 
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@EnableBatchProcessing
 public class EcoLocationBackApplication {
 
 	public static void main(String[] args) {

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/BatchConfig.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/BatchConfig.java
@@ -1,0 +1,19 @@
+package kr.ac.kumoh.webkit.ecolocationback.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class BatchConfig {
+
+    private final JobExplorer jobExplorer;
+
+
+    private final JobRepository jobRepository;
+
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/CsvReader.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/CsvReader.java
@@ -1,0 +1,45 @@
+package kr.ac.kumoh.webkit.ecolocationback.batch;
+
+import kr.ac.kumoh.webkit.ecolocationback.dto.GeneratorDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper;
+import org.springframework.batch.item.file.mapping.DefaultLineMapper;
+import org.springframework.batch.item.file.transform.DelimitedLineTokenizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+@RequiredArgsConstructor
+public class CsvReader {
+    @Bean
+    public ItemReader<? extends GeneratorDto> csvFileItemReader() {
+        /* file read */
+        FlatFileItemReader<GeneratorDto> flatFileItemReader = new FlatFileItemReader<>();
+        flatFileItemReader.setResource(new ClassPathResource("/csv/generators.csv"));
+        flatFileItemReader.setLinesToSkip(1); // header line skip
+        flatFileItemReader.setEncoding("UTF-8"); // encoding
+
+        /* read하는 데이터를 내부적으로 LineMapper을 통해 Mapping */
+        DefaultLineMapper<GeneratorDto> defaultLineMapper = new DefaultLineMapper<>();
+
+        /* delimitedLineTokenizer : setNames를 통해 각각의 데이터의 이름 설정 */
+        DelimitedLineTokenizer delimitedLineTokenizer = new DelimitedLineTokenizer(",");
+        delimitedLineTokenizer.setNames("companyName","generatorName", "generatorNum", "generateAmount", "memberType", "powerSupply", "powerSource", "generationType", "businessType", "wideArea", "detailArea");
+        delimitedLineTokenizer.setStrict(true);
+        defaultLineMapper.setLineTokenizer(delimitedLineTokenizer);
+
+        /* beanWrapperFieldSetMapper : Tokenizer에서 가지고온 데이터들을 VO로 바인드하는 역할 */
+        BeanWrapperFieldSetMapper<GeneratorDto> beanWrapperFieldSetMapper = new BeanWrapperFieldSetMapper<>();
+        beanWrapperFieldSetMapper.setTargetType(GeneratorDto.class);
+
+        defaultLineMapper.setFieldSetMapper(beanWrapperFieldSetMapper);
+
+        /* lineMapper 지정 */
+        flatFileItemReader.setLineMapper(defaultLineMapper);
+
+        return flatFileItemReader;
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/CsvToDbListener.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/CsvToDbListener.java
@@ -1,0 +1,25 @@
+package kr.ac.kumoh.webkit.ecolocationback.batch;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListenerSupport;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CsvToDbListener extends JobExecutionListenerSupport {
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+            System.out.println("Job completed successfully");
+        } else if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            System.out.println("Job failed with following exceptions: ");
+            List<Throwable> exceptionList = jobExecution.getAllFailureExceptions();
+            for (Throwable th : exceptionList) {
+                System.out.println("Exception: " + th.getLocalizedMessage());
+            }
+        }
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/CsvWriter.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/CsvWriter.java
@@ -1,0 +1,43 @@
+package kr.ac.kumoh.webkit.ecolocationback.batch;
+
+import kr.ac.kumoh.webkit.ecolocationback.dto.GeneratorDto;
+import kr.ac.kumoh.webkit.ecolocationback.entity.Generator;
+import kr.ac.kumoh.webkit.ecolocationback.repository.GeneratorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class CsvWriter implements ItemWriter<GeneratorDto> {
+
+    private final GeneratorRepository generatorRepository;
+
+    @Override
+    public void write(List<? extends GeneratorDto> list) throws Exception {
+        List<Generator> generatorList = new ArrayList<>();
+
+        // dto -> entity
+        list.forEach(getTempGenerator->{
+            Generator generator = Generator.builder()
+                    .companyName(getTempGenerator.getCompanyName())
+                    .generatorName(getTempGenerator.getGeneratorName())
+                    .generatorNum(getTempGenerator.getGeneratorNum())
+                    .generateAmount(getTempGenerator.getGenerateAmount())
+                    .memberType(getTempGenerator.getMemberType())
+                    .powerSupply(getTempGenerator.getPowerSupply())
+                    .powerSource(getTempGenerator.getPowerSource())
+                    .generationType(getTempGenerator.getGenerationType())
+                    .businessType(getTempGenerator.getBusinessType())
+                    .wideArea(getTempGenerator.getWideArea())
+                    .detailArea(getTempGenerator.getDetailArea())
+                    .build();
+            generatorList.add(generator);
+        });
+
+        generatorRepository.saveAll(new ArrayList<Generator>(generatorList));
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/FileItemReaderJobConfig.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/batch/FileItemReaderJobConfig.java
@@ -1,0 +1,40 @@
+package kr.ac.kumoh.webkit.ecolocationback.batch;
+
+import kr.ac.kumoh.webkit.ecolocationback.dto.GeneratorDto;
+import kr.ac.kumoh.webkit.ecolocationback.entity.Generator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FileItemReaderJobConfig {
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final CsvReader csvReader;
+    private final CsvWriter csvWriter;
+
+    private static final int chunkSize = 1000;
+
+    @Bean
+    public Job csvFileItemReaderJob() {
+        return jobBuilderFactory.get("csvFileItemReaderJob")
+                .start(csvFileItemReaderStep())
+                .build();
+    }
+
+    @Bean
+    public Step csvFileItemReaderStep() {
+        return stepBuilderFactory.get("csvFileItemReaderStep")
+                .<GeneratorDto, GeneratorDto>chunk(chunkSize)
+                .reader(csvReader.csvFileItemReader())
+                .writer(csvWriter)
+                .build();
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/GeneratorDto.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/GeneratorDto.java
@@ -1,0 +1,29 @@
+package kr.ac.kumoh.webkit.ecolocationback.dto;
+
+import lombok.Data;
+
+@Data
+public class GeneratorDto {
+    // 회사명
+    private String companyName;
+    // 발전기명
+    private String generatorName;
+    // 호기
+    private String generatorNum;
+    // 설비용량
+    private String generateAmount;
+    // 회원구분
+    private String memberType;
+    // 급전방식
+    private String powerSupply;
+    // 발전원
+    private String powerSource;
+    // 발전종류
+    private String generationType;
+    // 사업구분
+    private String businessType;
+    // 광역지역
+    private String wideArea;
+    // 세부지역
+    private String detailArea;
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/entity/Generator.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/entity/Generator.java
@@ -1,0 +1,57 @@
+package kr.ac.kumoh.webkit.ecolocationback.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@Table(name = "generators")
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@Entity
+public class Generator {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "generator_id")
+    private Long id;
+
+    // 회사명
+    private String companyName;
+    // 발전기명
+    private String generatorName;
+    // 호기
+    private String generatorNum;
+    // 설비용량
+    private String generateAmount;
+    // 회원구분
+    private String memberType;
+    // 급전방식
+    private String powerSupply;
+    // 발전원
+    private String powerSource;
+    // 발전종류
+    private String generationType;
+    // 사업구분
+    private String businessType;
+    // 광역지역
+    private String wideArea;
+    // 세부지역
+    private String detailArea;
+
+    @Builder
+    public Generator(String companyName, String generatorName, String generatorNum, String generateAmount, String memberType, String powerSupply, String powerSource, String generationType, String businessType, String wideArea, String detailArea) {
+        this.companyName = companyName;
+        this.generatorName = generatorName;
+        this.generatorNum = generatorNum;
+        this.generateAmount = generateAmount;
+        this.memberType = memberType;
+        this.powerSupply = powerSupply;
+        this.powerSource = powerSource;
+        this.generationType = generationType;
+        this.businessType = businessType;
+        this.wideArea = wideArea;
+        this.detailArea = detailArea;
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/repository/GeneratorRepository.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/repository/GeneratorRepository.java
@@ -1,0 +1,7 @@
+package kr.ac.kumoh.webkit.ecolocationback.repository;
+
+import kr.ac.kumoh.webkit.ecolocationback.entity.Generator;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GeneratorRepository extends JpaRepository<Generator, Long> {
+}


### PR DESCRIPTION
### 기능 설명
- spring batch를 사용하여 많은 양의 데이터 작업 처리
- kafka와 batch 중 고민했는데 보통 kafka는 실시간 처리 스트림으로 사용하고 batch는 형태가 정해진 작업에 사용한다고 하여 형태가 정해진 csv파일을 저장하기 위해 batch 사용.
- chunkSize만큼 불러온 다음 db에 한번에 저장

### 추가 설명
- 추가로 저장할 csv가 생긴다면 다음과 같은 순서로 진행한다.
1. 저장할 데이터의 entity와 dto 작성
2. FileItemReaderJobConfig에 새로운 Step 빈을 만들고 작업할 내용 reader와 writer 데이터에 맞게 작성
3. 만든 Step을 추가하여 실행하는 Job도 추가

close #3 