### PR TITLE
[feat] GeneratorController, GeneratorService 추가

### DIFF
--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GeneratorController.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GeneratorController.java
@@ -1,0 +1,37 @@
+package kr.ac.kumoh.webkit.ecolocationback.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.ac.kumoh.webkit.ecolocationback.entity.Generator;
+import kr.ac.kumoh.webkit.ecolocationback.service.GeneratorService;
+
+@RestController
+@RequestMapping("/generators")
+public class GeneratorController {
+
+    @Autowired
+    private GeneratorService generatorService;
+
+    @GetMapping
+    public List<Generator> getAllGenerators() {
+        return generatorService.getAllGenerators();
+    }
+    
+    @GetMapping(params = "detailArea")
+    public List<Generator> getGeneratorsByDetailArea(@RequestParam("detailArea") String detailArea) {
+        return generatorService.getGeneratorsByDetailArea(detailArea);
+    }
+    
+    @GetMapping(params = "powerSource")
+    public List<Generator> getGeneratorsByPowerSource(@RequestParam("powerSource") String powerSource) {
+        return generatorService.getGeneratorsByPowerSource(powerSource);
+    }
+
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/repository/GeneratorRepository.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/repository/GeneratorRepository.java
@@ -1,7 +1,13 @@
 package kr.ac.kumoh.webkit.ecolocationback.repository;
 
 import kr.ac.kumoh.webkit.ecolocationback.entity.Generator;
+
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GeneratorRepository extends JpaRepository<Generator, Long> {
+	
+	List<Generator> findByDetailArea(String detailArea);
+	List<Generator> findByPowerSource(String powerSource);
 }

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GeneratorService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GeneratorService.java
@@ -1,0 +1,36 @@
+package kr.ac.kumoh.webkit.ecolocationback.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import kr.ac.kumoh.webkit.ecolocationback.entity.Generator;
+import kr.ac.kumoh.webkit.ecolocationback.repository.GeneratorRepository;
+
+@Service
+public class GeneratorService {
+
+    @Autowired
+    private GeneratorRepository generatorRepository;
+
+    public List<Generator> getAllGenerators() {
+        return generatorRepository.findAll();
+    }
+
+    public Generator saveGenerator(Generator generator) {
+        return generatorRepository.save(generator);
+    }
+
+    public List<Generator> saveGenerators(List<Generator> generators) {
+        return generatorRepository.saveAll(generators);
+    }
+    
+    public List<Generator> getGeneratorsByDetailArea(String detailArea){
+    	return generatorRepository.findByDetailArea(detailArea);
+    }
+    
+    public List<Generator> getGeneratorsByPowerSource(String powerSource){
+    	return generatorRepository.findByPowerSource(powerSource);
+    }
+}


### PR DESCRIPTION
발전원별 검색기능, 세부지역별 검색기능 추가

GET방식으로 로컬호스트/generators/
주소에서 받아오면 됩니다.

세부지역별 검색기능 파라미터 : ?detailArea=경상북도 경산시 
이렇게 하면 해당하는 발전소 정보를 받아옵니다.

발전원별 검색기능 파라미터 : ?powerSource=태양에너지
이렇게 하면 해당하는 발전소 정보를 받아옵니다.
유의점 : 태양에너지 전체 데이터가 많아서 응답시간이 좀 걸립니다.

포스트맨에서 받아온 모양 : 
```json
[
    {
        "id": 964,
        "companyName": "(주)GS E R",
        "generatorName": "반월열병합",
        "generatorNum": "1",
        "generateAmount": "83.46",
        "memberType": "정회원",
        "powerSupply": "비중앙",
        "powerSource": "석탄",
        "generationType": "기력",
        "businessType": "집단에너지사업",
        "wideArea": "경기",
        "detailArea": "경기도 안산시"
    },
    {
        "id": 966,
        "companyName": "(주)GS E R 구미",
        "generatorName": "구미열병합",
        "generatorNum": "1",
        "generateAmount": "97.10",
        "memberType": "정회원",
        "powerSupply": "비중앙",
        "powerSource": "석탄",
        "generationType": "기력",
        "businessType": "집단에너지사업",
        "wideArea": "경북",
        "detailArea": "경상북도 구미시"
     }
]
```


석탄으로 검색하면 대략 이런 식으로 데이터를 받아옵니다.(갯수는 더 많은데 줄여놓았음)

close #10 