### PR TITLE
[S1-R12] 발전원별 잠재량 표시 기능 구현

### DIFF
--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/EnergyPotentialController.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/EnergyPotentialController.java
@@ -1,6 +1,7 @@
 package kr.ac.kumoh.webkit.ecolocationback.controller;
 
 import kr.ac.kumoh.webkit.ecolocationback.dto.response.PotentialByRegionDto;
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.PotentialBySourceDto;
 import kr.ac.kumoh.webkit.ecolocationback.entity.EnergyPotential;
 import kr.ac.kumoh.webkit.ecolocationback.service.EnergyPotentialService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,5 +41,18 @@ public class EnergyPotentialController {
         LocalDateTime start = LocalDateTime.of(year, 1, 1, 0, 0);
         LocalDateTime end = LocalDateTime.of(year, 1, 2, 23, 59);
         return energyPotentialService.getAllEnergyPotentialByDate(start,end);
+    }
+
+    /**
+     * @param year 조회할 년도
+     * @param region 조회할 지역
+     * @return 태양, 풍력 잠재량 데이터(Wh)
+     */
+    // 발전원별 잠재량 표시
+    @GetMapping("/source-type")
+    public PotentialBySourceDto getEnergyPotentialByRegionAndYear(@RequestParam("year") int year, @RequestParam("region")String region){
+        LocalDateTime start = LocalDateTime.of(year, 1, 1, 0, 0);
+        LocalDateTime end = LocalDateTime.of(year, 1, 2, 23, 59);
+        return energyPotentialService.getAllEnergyPotentialByDateAndRegion(start,end,region);
     }
 }

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/PotentialBySourceDto.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/PotentialBySourceDto.java
@@ -1,0 +1,24 @@
+package kr.ac.kumoh.webkit.ecolocationback.dto.response;
+
+import kr.ac.kumoh.webkit.ecolocationback.entity.EnergyPotential;
+import lombok.Data;
+
+@Data
+public class PotentialBySourceDto {
+    private double potentialOfSolar = 0;
+    private double potentialOfWind = 0;
+
+    public void addPotentialByEntity(EnergyPotential item) {
+        switch (item.getPowerType()) {
+            case "1":
+                this.potentialOfSolar += item.getForecastEnergyPotential();
+                break;
+            case "2":
+                this.potentialOfWind += item.getForecastEnergyPotential();
+                break;
+            default:
+                // 예외 처리
+                break;
+        }
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/repository/EnergyPotentialRepository.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/repository/EnergyPotentialRepository.java
@@ -10,6 +10,7 @@ public interface EnergyPotentialRepository extends JpaRepository<EnergyPotential
 
     // 사용자가 원하는 기간을 지정하여 보내면 지정된 시간대 사이의 잠재 발전량 데이터를 전부 전송한다.
     List<EnergyPotential> findByForecastTimeBetween(LocalDateTime firstForecastTime, LocalDateTime secondForecastTime);
+    List<EnergyPotential> findByForecastTimeBetweenAndAreaName(LocalDateTime firstForecastTime, LocalDateTime secondForecastTime, String region);
     List<EnergyPotential> findByPowerTypeAndForecastTimeBetween(String powerType,LocalDateTime startTime, LocalDateTime endTime);
 }
 

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/EnergyPotentialService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/EnergyPotentialService.java
@@ -1,6 +1,7 @@
 package kr.ac.kumoh.webkit.ecolocationback.service;
 
 import kr.ac.kumoh.webkit.ecolocationback.dto.response.PotentialByRegionDto;
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.PotentialBySourceDto;
 import kr.ac.kumoh.webkit.ecolocationback.entity.EnergyPotential;
 import kr.ac.kumoh.webkit.ecolocationback.repository.EnergyPotentialRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,16 @@ public class EnergyPotentialService {
     public PotentialByRegionDto getAllEnergyPotentialByDate(LocalDateTime startTime, LocalDateTime endTime) {
         List<EnergyPotential> energyPotentialList = energyPotentialRepository.findByForecastTimeBetween(startTime,endTime);
         PotentialByRegionDto response = new PotentialByRegionDto();
+        for (EnergyPotential item:
+                energyPotentialList) {
+            response.addPotentialByEntity(item);
+        }
+        return response;
+    }
+
+    public PotentialBySourceDto getAllEnergyPotentialByDateAndRegion(LocalDateTime startTime, LocalDateTime endTime, String region) {
+        List<EnergyPotential> energyPotentialList = energyPotentialRepository.findByForecastTimeBetweenAndAreaName(startTime, endTime, region);
+        PotentialBySourceDto response = new PotentialBySourceDto();
         for (EnergyPotential item:
                 energyPotentialList) {
             response.addPotentialByEntity(item);


### PR DESCRIPTION
### 구현 내용
#### API GET /energy-potential/source-type?year={조회년도}&region={조회지역}
- 조회 지역은 경기도, 강원도, 충청도, 전라북도, 전라남도, 경상북도, 경상남도, 제주도가 있습니다.\
response
```json
{
    "potentialOfSolar": 924.9715164540003,
    "potentialOfWind": 38003.022187
}
```

### 추가 사항
- 지역을 자주 사용하는 것 같은데 enum 클래스로 통합하면 좋겠습니다.
- 동일한 resource에 대해 다양한 조회 쿼리를 사용하여 동적 쿼리를 사용하면 좋을 것 같습니다.

close #17 