### PR TITLE
기간 데이터에 대해 지역별로 신재생 에너지의 잠재량과 발전량을 반환하는 기능 구현

### DIFF
--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/ComparePotentialAndGenerateController.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/ComparePotentialAndGenerateController.java
@@ -1,0 +1,33 @@
+package kr.ac.kumoh.webkit.ecolocationback.controller;
+
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.ComparePotentialAndGenerateDto;
+import kr.ac.kumoh.webkit.ecolocationback.entity.EnergyPotential;
+import kr.ac.kumoh.webkit.ecolocationback.service.ComparePotentialAndGenerateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/compare")
+@RequiredArgsConstructor
+public class ComparePotentialAndGenerateController {
+    private final ComparePotentialAndGenerateService comparePotentialAndGenerateService;
+
+    /**
+     * @param start
+     * @param end
+     * @return 지역별로 해당 기간 사이의 신재생 에너지 잠재량과 발전량을 반환.
+     */
+    @GetMapping
+    public List<ComparePotentialAndGenerateDto> getComparePotentialAndGenerateDto(
+            @RequestParam("from") @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime start,
+            @RequestParam("to") @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime end){
+        return comparePotentialAndGenerateService.comparePotentialAndGenerate(start, end);
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/ComparePotentialAndGenerateDto.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/ComparePotentialAndGenerateDto.java
@@ -1,0 +1,16 @@
+package kr.ac.kumoh.webkit.ecolocationback.dto.response;
+
+import lombok.Data;
+
+@Data
+public class ComparePotentialAndGenerateDto {
+    private String areaName;
+    private double potentialAmount;
+    private double generateAmount;
+
+    public ComparePotentialAndGenerateDto(String areaName, double forecastEnergyPotential, double i) {
+        this.areaName = areaName;
+        this.potentialAmount = forecastEnergyPotential;
+        this.generateAmount = i;
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/ComparePotentialAndGenerateService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/ComparePotentialAndGenerateService.java
@@ -168,7 +168,7 @@ public class ComparePotentialAndGenerateService {
                     .mapToDouble(EnergyPotential::getForecastEnergyPotential)
                     .sum();
         }
-        BigDecimal bigDecimal = BigDecimal.valueOf(potentialAmount);
+        BigDecimal bigDecimal = BigDecimal.valueOf(potentialAmount * 0.000001);
         formattedNumber = bigDecimal.toPlainString();
 
         return Double.parseDouble(formattedNumber);
@@ -191,7 +191,7 @@ public class ComparePotentialAndGenerateService {
             List<AreaGeneratorSource> areaGeneratorSources = groupedAreaGeneratorSources.get(area);
             if (areaGeneratorSources != null) {
                 generateAmount = areaGeneratorSources.stream()
-                        .mapToDouble(ag -> Double.parseDouble(ag.getSrcRecycleSum())).sum();
+                        .mapToDouble(ag -> Double.parseDouble(ag.getSrcSolar())+Double.parseDouble(ag.getSrcWind())).sum();
             }
             BigDecimal bigDecimal = BigDecimal.valueOf(generateAmount);
             formattedNumber = bigDecimal.toPlainString();

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/ComparePotentialAndGenerateService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/ComparePotentialAndGenerateService.java
@@ -1,0 +1,202 @@
+package kr.ac.kumoh.webkit.ecolocationback.service;
+
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.ComparePotentialAndGenerateDto;
+import kr.ac.kumoh.webkit.ecolocationback.entity.AreaGeneratorSource;
+import kr.ac.kumoh.webkit.ecolocationback.entity.EnergyPotential;
+import kr.ac.kumoh.webkit.ecolocationback.repository.AreaGeneratorSourceRepository;
+import kr.ac.kumoh.webkit.ecolocationback.repository.EnergyPotentialRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ComparePotentialAndGenerateService {
+    private final AreaGeneratorSourceRepository areaGeneratorSourceRepository;
+    private final EnergyPotentialRepository energyPotentialRepository;
+
+    public List<ComparePotentialAndGenerateDto> comparePotentialAndGenerate(LocalDateTime startTime, LocalDateTime endTime) {
+        List<EnergyPotential> energyPotentialList = energyPotentialRepository.findByForecastTimeBetween(startTime, endTime);
+        LocalDate startLocalDate = startTime.toLocalDate();
+        LocalDate endLocalDate = endTime.toLocalDate();
+        List<AreaGeneratorSource> areaGeneratorSourceList = areaGeneratorSourceRepository.findByDateBetween(startLocalDate, endLocalDate);
+
+        List<ComparePotentialAndGenerateDto> response = mapToDtoList(energyPotentialList, areaGeneratorSourceList);
+
+        return response;
+    }
+
+    /**
+     * @param energyPotentials
+     * @param areaGeneratorSources
+     * @return
+     * @description 리스트를 가져와 해당하는 지역으로 그룹화 하고 dto변환하는 함수
+     */
+    public static List<ComparePotentialAndGenerateDto> mapToDtoList(
+            List<EnergyPotential> energyPotentials, List<AreaGeneratorSource> areaGeneratorSources){
+
+        // 지역별로 그룹화된 EnergyPotential 맵 생성
+        Map<String, List<EnergyPotential>> groupedEnergyPotentials = energyPotentials.stream()
+                .collect(Collectors.groupingBy(EnergyPotential::getAreaName));
+        // 지역별로 그룹화 된 AreaGenerator 맵 생성
+        Map<String, List<AreaGeneratorSource>> groupedAreaGeneratorSources = areaGeneratorSources.stream()
+                .collect(Collectors.groupingBy(AreaGeneratorSource::getArea));
+
+        List<ComparePotentialAndGenerateDto> dtos = generateDtos(groupedEnergyPotentials, groupedAreaGeneratorSources);
+
+        return dtos;
+    }
+
+    /**
+     * @param groupedEnergyPotentials
+     * @param groupedAreaGeneratorSources
+     * @return
+     * @description Map들을 가져와 지역에 맞추어 DtoList를 생성하는 함수
+     */
+    public static List<ComparePotentialAndGenerateDto> generateDtos(
+            Map<String, List<EnergyPotential>> groupedEnergyPotentials,
+            Map<String, List<AreaGeneratorSource>> groupedAreaGeneratorSources) {
+
+        List<ComparePotentialAndGenerateDto> dtos = new ArrayList<>();
+
+        // 강원도
+        String areaName = "강원도";
+        List<String> includedAreas = List.of("강원");
+
+        double potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        double generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        ComparePotentialAndGenerateDto dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        // 경기도
+        areaName = "경기도";
+        includedAreas = List.of("서울", "세종", "인천", "경기");
+
+        potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        // 충청도
+        areaName = "충청도";
+        includedAreas = List.of("대전", "충북", "충남");
+
+        potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        // 경상북도
+        areaName = "경상북도";
+        includedAreas = List.of("대구", "경북");
+
+        potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        // 경상남도
+        areaName = "경상남도";
+        includedAreas = List.of("부산", "울산", "경남");
+
+        potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        // 전라북도
+        areaName = "전라북도";
+        includedAreas = List.of("전북");
+
+        potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        // 전라남도
+        areaName = "전라남도";
+        includedAreas = List.of("광주", "전남");
+
+        potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        // 제주도
+        areaName = "제주도";
+        includedAreas = List.of("제주");
+
+        potentialAmount = calculatePotentialAmount(groupedEnergyPotentials, areaName);
+        generateAmount = calculateGenerateAmount(groupedAreaGeneratorSources, includedAreas);
+
+        dto = new ComparePotentialAndGenerateDto(areaName, potentialAmount, generateAmount);
+        dtos.add(dto);
+
+        return dtos;
+    }
+
+    /**
+     * @param groupedEnergyPotentials
+     * @param areaName
+     * @return
+     * @description 해당하는 area의 energyPotential을 가져와서 잠재량 더하여 반환하는 메소드
+     */
+    private static double calculatePotentialAmount(
+            Map<String, List<EnergyPotential>> groupedEnergyPotentials,
+            String areaName) {
+
+        double potentialAmount = 0;
+        String formattedNumber = "";
+
+        List<EnergyPotential> energyPotentials = groupedEnergyPotentials.get(areaName);
+        if (energyPotentials != null) {
+            potentialAmount += energyPotentials.stream()
+                    .mapToDouble(EnergyPotential::getForecastEnergyPotential)
+                    .sum();
+        }
+        BigDecimal bigDecimal = BigDecimal.valueOf(potentialAmount);
+        formattedNumber = bigDecimal.toPlainString();
+
+        return Double.parseDouble(formattedNumber);
+    }
+
+    /**
+     * @param groupedAreaGeneratorSources
+     * @param includedAreas
+     * @return
+     * @description 해당하는 includedAreas의 energyPotential을 가져와서 잠재량 더하여 반환하는 메소드
+     */
+    private static double calculateGenerateAmount(
+            Map<String, List<AreaGeneratorSource>> groupedAreaGeneratorSources,
+            List<String> includedAreas) {
+
+        double generateAmount = 0;
+        String formattedNumber = "";
+
+        for (String area : includedAreas) {
+            List<AreaGeneratorSource> areaGeneratorSources = groupedAreaGeneratorSources.get(area);
+            if (areaGeneratorSources != null) {
+                generateAmount = areaGeneratorSources.stream()
+                        .mapToDouble(ag -> Double.parseDouble(ag.getSrcRecycleSum())).sum();
+            }
+            BigDecimal bigDecimal = BigDecimal.valueOf(generateAmount);
+            formattedNumber = bigDecimal.toPlainString();
+        }
+
+        return Double.parseDouble(formattedNumber);
+    }
+}


### PR DESCRIPTION
### 구현 내용
- 기간을 받아 해당 기간 사이의 신재생에너지 잠재량과 실제 발전량 데이터를 가져와 지역별로 반환한다.

### API
request : GET /compare?from=2020-10-01 12:00:00&to=2020-10-31 23:59:59
response : 
```json
[
    {
        "areaName": "강원도",
        "potentialAmount": 1392.1375372933994,
        "generateAmount": 23657.749202
    },
    {
        "areaName": "경기도",
        "potentialAmount": 1109.3191898753573,
        "generateAmount": 14364.3811
    },
    {
        "areaName": "충청도",
        "potentialAmount": 0,
        "generateAmount": 29609.80728
    },
    {
        "areaName": "경상북도",
        "potentialAmount": 2655.873693549909,
        "generateAmount": 37593.306543
    },
    {
        "areaName": "경상남도",
        "potentialAmount": 1129.059849503512,
        "generateAmount": 17279.752002999998
    },
    {
        "areaName": "전라북도",
        "potentialAmount": 2486.4549879517854,
        "generateAmount": 46180.920755
    },
    {
        "areaName": "전라남도",
        "potentialAmount": 3001.4958698899063,
        "generateAmount": 56685.29563000001
    },
    {
        "areaName": "제주도",
        "potentialAmount": 1109.0905457017388,
        "generateAmount": 10181.85283
    }
]
```

close #40