### PR TITLE
[feat] 프론트 엔드를 위한 발전소 데이터 정제 구현

### DIFF
--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GeneratorController.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GeneratorController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import kr.ac.kumoh.webkit.ecolocationback.dto.GeneratorDto;
 import kr.ac.kumoh.webkit.ecolocationback.dto.response.GeneratorCountDto;
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.RefineGeneratorDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,4 +46,8 @@ public class GeneratorController {
         return ResponseEntity.ok().body(generatorCountDto);
     }
 
+    @GetMapping("/refine")
+    public List<RefineGeneratorDto> getRefineGenerators(){
+        return generatorService.GeneratorRefine();
+    }
 }

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/GeneratorDto.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/GeneratorDto.java
@@ -11,7 +11,7 @@ public class GeneratorDto {
     // 호기
     private String generatorNum;
     // 설비용량
-    private String generateAmount;
+    private double generateAmount;
     // 회원구분
     private String memberType;
     // 급전방식

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/RefineGeneratorDto.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/RefineGeneratorDto.java
@@ -1,0 +1,16 @@
+package kr.ac.kumoh.webkit.ecolocationback.dto.response;
+
+import lombok.Data;
+
+@Data
+public class RefineGeneratorDto {
+    private String wideArea;
+    private String powerSource;
+    private double amount;
+
+    public RefineGeneratorDto(String wideArea, String powerSource, double amount){
+        this.wideArea = wideArea;
+        this.powerSource = powerSource;
+        this.amount = amount;
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/entity/Generator.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/entity/Generator.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @Data
 @Table(name = "generators")
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
-@Entity
+@Entity(name="Generator")
 public class Generator {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,7 +24,7 @@ public class Generator {
     // 호기
     private String generatorNum;
     // 설비용량
-    private String generateAmount;
+    private double generateAmount;
     // 회원구분
     private String memberType;
     // 급전방식
@@ -41,7 +41,7 @@ public class Generator {
     private String detailArea;
 
     @Builder
-    public Generator(String companyName, String generatorName, String generatorNum, String generateAmount, String memberType, String powerSupply, String powerSource, String generationType, String businessType, String wideArea, String detailArea) {
+    public Generator(String companyName, String generatorName, String generatorNum, double generateAmount, String memberType, String powerSupply, String powerSource, String generationType, String businessType, String wideArea, String detailArea) {
         this.companyName = companyName;
         this.generatorName = generatorName;
         this.generatorNum = generatorNum;

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GeneratorService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GeneratorService.java
@@ -1,13 +1,17 @@
 package kr.ac.kumoh.webkit.ecolocationback.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import kr.ac.kumoh.webkit.ecolocationback.dto.response.GeneratorCountDto;
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.RefineGeneratorDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import kr.ac.kumoh.webkit.ecolocationback.entity.Generator;
 import kr.ac.kumoh.webkit.ecolocationback.repository.GeneratorRepository;
+
+import javax.persistence.*;
 
 @Service
 public class GeneratorService {
@@ -45,5 +49,19 @@ public class GeneratorService {
         }
 
         return generatorCountDto;
+    }
+
+    @PersistenceContext
+    private EntityManager em;
+    public List<RefineGeneratorDto> GeneratorRefine(){
+        TypedQuery<RefineGeneratorDto> query = em.createQuery(
+                "SELECT NEW kr.ac.kumoh.webkit.ecolocationback.dto.response.RefineGeneratorDto" +
+                        "(g.wideArea, g.powerSource, SUM(g.generateAmount) as amount) FROM Generator g " +
+                        "where g.powerSource in ('바이오에너지', '수력에너지', '연료전지', '태양에너지', '풍력에너지')" +
+                        " GROUP BY g.wideArea, g.powerSource",
+                RefineGeneratorDto.class);
+        List<RefineGeneratorDto> resultList = query.getResultList();
+
+        return resultList;
     }
 }


### PR DESCRIPTION
[#41](https://github.com/web-eco-location/eco-location-back/issues/41)을 위한 기능을 구현했습니다.
generator와 dto의 설비용량(generateAmount)을 string에서 double로 변경했습니다.