### PR TITLE
지역을 입력받아 해당 지역의 연도별 월평균 발전량 구하는 기능 구현

### DIFF
--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GenerateAmountController.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GenerateAmountController.java
@@ -1,9 +1,15 @@
 package kr.ac.kumoh.webkit.ecolocationback.controller;
 
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.GenerateAmountByYearDto;
 import kr.ac.kumoh.webkit.ecolocationback.service.GenerateAmountService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,5 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class GenerateAmountController {
     private final GenerateAmountService generateAmountService;
 
+    @GetMapping("/average")
+    public ResponseEntity<List<GenerateAmountByYearDto>> getGenerators(@RequestParam("area") String detailArea){
+        List<GenerateAmountByYearDto> response = generateAmountService.getGenerateAmountAverageByArea(detailArea);
 
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/GenerateAmountByYearDto.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/GenerateAmountByYearDto.java
@@ -1,0 +1,55 @@
+package kr.ac.kumoh.webkit.ecolocationback.dto.response;
+
+import kr.ac.kumoh.webkit.ecolocationback.entity.AreaGeneratorSource;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Data
+public class GenerateAmountByYearDto {
+    private int year;
+    private double generateSolarAmountAverage;
+    private double generateWindAmountAverage;
+
+    public GenerateAmountByYearDto(Year year, List<AreaGeneratorSource> sources) {
+        this.year = year.getValue();
+        calculateAverages(sources);
+    }
+
+    private void calculateAverages(List<AreaGeneratorSource> sources) {
+        double solarSum = 0.0;
+        double windSum = 0.0;
+
+        for (AreaGeneratorSource source : sources) {
+            solarSum += source.getSrcSolar();
+            windSum += source.getSrcWind();
+        }
+
+        this.generateSolarAmountAverage = solarSum / sources.size();
+        this.generateWindAmountAverage = windSum / sources.size();
+    }
+
+    public static List<GenerateAmountByYearDto> calculateAveragesByYear(List<AreaGeneratorSource> areaGeneratorSources) {
+        // 날짜별로 AreaGeneratorSource를 그룹화
+        Map<Year, List<AreaGeneratorSource>> groupedSources = areaGeneratorSources.stream()
+                .collect(Collectors.groupingBy(source -> Year.of(LocalDate.parse(source.getDate().toString()).getYear())));
+
+        List<GenerateAmountByYearDto> result = new ArrayList<>();
+
+        // 각 년도별로 평균 계산하여 GenerateAmountByYearDto 객체 생성
+        for (Map.Entry<Year, List<AreaGeneratorSource>> entry : groupedSources.entrySet()) {
+            Year year = entry.getKey();
+            List<AreaGeneratorSource> sources = entry.getValue();
+
+            GenerateAmountByYearDto dto = new GenerateAmountByYearDto(year, sources);
+            result.add(dto);
+        }
+
+        return result;
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GenerateAmountService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GenerateAmountService.java
@@ -1,8 +1,13 @@
 package kr.ac.kumoh.webkit.ecolocationback.service;
 
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.GenerateAmountByYearDto;
+import kr.ac.kumoh.webkit.ecolocationback.entity.AreaGeneratorSource;
 import kr.ac.kumoh.webkit.ecolocationback.repository.AreaGeneratorSourceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -11,6 +16,14 @@ public class GenerateAmountService {
 
     // 연도를 입력받아 지역별로 발전량을 반환하는 메소드.
 
-    // 지역을 입력 받아 발전원 별로 발전량을 표시한다. 18~23년도별 연평균 발전량을 반환하는 메소드.
 
+    // 지역을 입력 받아 발전원 별로 발전량을 표시한다. 18~23년도별 연평균 발전량을 반환하는 메소드.
+    public List<GenerateAmountByYearDto> getGenerateAmountAverageByArea(String areaName) {
+        List<AreaGeneratorSource> sourceList = areaGeneratorSourceRepository.findByArea(areaName);
+        if (sourceList.size() == 0) throw new NoSuchElementException("해당하는 지역의 데이터가 없습니다");
+
+        List<GenerateAmountByYearDto> result = GenerateAmountByYearDto.calculateAveragesByYear(sourceList);
+
+        return result;
+    }
 }


### PR DESCRIPTION
### 구현 내용
- 년도, 태양에너지, 풍력에너지 정보를 가진 dto를 새로 작성.
- 지역 이름으로 엔티티 리스트를 찾아온 후 해당 리스트로 dto 리스트를 만드는 static 메소드 구현하여 사용함.

close #21 