### PR TITLE
[feat] 연도를 입력받아 지역별로 발전량을 반환하는 기능 구현

### DIFF
--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GenerateAmountController.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/controller/GenerateAmountController.java
@@ -1,9 +1,14 @@
 package kr.ac.kumoh.webkit.ecolocationback.controller;
 
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.GenerateAmountByAreaDto;
 import kr.ac.kumoh.webkit.ecolocationback.service.GenerateAmountService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,5 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class GenerateAmountController {
     private final GenerateAmountService generateAmountService;
 
-
+    @GetMapping(params = "date")
+    public List<GenerateAmountByAreaDto> getGenerateAmountArea(@RequestParam("date") String date){
+        return generateAmountService.GenerateAmountAreaByYear(date);
+    }
 }

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/GenerateAmountByAreaDto.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/dto/response/GenerateAmountByAreaDto.java
@@ -1,0 +1,16 @@
+package kr.ac.kumoh.webkit.ecolocationback.dto.response;
+
+import lombok.Data;
+
+@Data
+public class GenerateAmountByAreaDto {
+    private String area;
+    private double solarAmount;
+    private double windAmount;
+
+    public GenerateAmountByAreaDto(String area, double solarAmount, double windAmount){
+        this.area = area;
+        this.solarAmount = solarAmount;
+        this.windAmount = windAmount;
+    }
+}

--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GenerateAmountService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/GenerateAmountService.java
@@ -1,15 +1,40 @@
 package kr.ac.kumoh.webkit.ecolocationback.service;
 
+import kr.ac.kumoh.webkit.ecolocationback.dto.response.GenerateAmountByAreaDto;
 import kr.ac.kumoh.webkit.ecolocationback.repository.AreaGeneratorSourceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
 public class GenerateAmountService {
+
+    @Autowired
     private final AreaGeneratorSourceRepository areaGeneratorSourceRepository;
 
     // 연도를 입력받아 지역별로 발전량을 반환하는 메소드.
+    @PersistenceContext
+    private EntityManager entityManager;
+    public List<GenerateAmountByAreaDto> GenerateAmountAreaByYear(String date){
+        TypedQuery<GenerateAmountByAreaDto> query = entityManager.createQuery(
+                "select NEW kr.ac.kumoh.webkit.ecolocationback.dto.response.GenerateAmountByAreaDto" +
+                        "(a.area, sum(a.srcSolar) as solarAmount, sum(a.srcWind) as windAmount) " +
+                        "FROM kr.ac.kumoh.webkit.ecolocationback.entity.AreaGeneratorSource a " +
+                        "where a.date like '" + date + "%' group by a.area"
+        , GenerateAmountByAreaDto.class);
+        List<GenerateAmountByAreaDto> resultList = query.getResultList();
+
+        if (resultList.size() == 0) throw new NoSuchElementException("해당하는 년도의 데이터가 없습니다");
+
+        return resultList;
+    }
 
     // 지역을 입력 받아 발전원 별로 발전량을 표시한다. 18~23년도별 연평균 발전량을 반환하는 메소드.
 


### PR DESCRIPTION
**구현 내용**
- 지역, 태양력, 풍력 발전량 합계의 정보를 가진 DTO 작성
- jpql을 이용하여 연도의 데이터가 입력되면 해당되는 데이터를 리스트로 쿼리로 받은 후 dto 리스트를 만드는 방식으로 구현함.   