### PR TITLE
[fix] 파일을 절대 경로로 열었던 것을 상대 경로로 수정

### DIFF
--- a/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/DatabaseInitializerService.java
+++ b/eco-location-back/src/main/java/kr/ac/kumoh/webkit/ecolocationback/service/DatabaseInitializerService.java
@@ -38,9 +38,9 @@ public class DatabaseInitializerService {
     public void initializeDatabase() {
         clearRepositories();
 
-        inputData("generator", "/csv/generators.csv");
-        inputData("energyPotential", "/csv/totalEnergyPotential.csv");
-        inputData("areaGeneratorSource", "/csv/AreaGeneratorSource.csv");
+        inputData("generator", "src/main/resources/csv/generators.csv");
+        inputData("energyPotential", "src/main/resources/csv/totalEnergyPotential.csv");
+        inputData("areaGeneratorSource", "src/main/resources/csv/AreaGeneratorSource.csv");
     }
     private void clearRepositories() {
         // 모든 리포지토리의 데이터 삭제
@@ -52,10 +52,7 @@ public class DatabaseInitializerService {
 
     public void inputData(String jobId, String filePath) {
         try {
-            String curWorkingDir = System.getProperty("user.dir");
-            String path = curWorkingDir + "/src/main/resources";
-
-            CSVReader csvReader = new CSVReaderBuilder(new FileReader(path + filePath)).withSkipLines(1).build();
+            CSVReader csvReader = new CSVReaderBuilder(new FileReader(filePath)).withSkipLines(1).build();
             String[] line;
             List<GeneratorDto> generatorDtos = new ArrayList<>();
             List<EnergyPotentialDto> energyPotentialDtos = new ArrayList<>();


### PR DESCRIPTION
DB 데이터 초기화 후, 데이터를 다시 입력하는 inputData 함수가 읽어들이는 CSV 파일을 절대 경로에서 상대 경로로 읽는 것으로 수정. 

로컬 서버가 아니라 공개 서버에서도 제대로 파일을 읽고 함수가 실행되는지 확인이 필요함.